### PR TITLE
ci: add GitHub Actions for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary
- Add CI workflow that runs on PRs and pushes to main
- Run ESLint, Prettier check, and build steps
- Add `format:check` script for CI validation

## Workflow Steps
1. Checkout code
2. Setup Node 24 with npm cache
3. Install dependencies (`npm ci`)
4. Lint (`npm run lint`)
5. Check formatting (`npm run format:check`)
6. Build (`npm run build`)

## Test plan
- [ ] CI workflow runs on this PR
- [ ] All checks pass (lint, format, build)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)