### PR TITLE
ci: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  base: "/pomoflex/",
 });


### PR DESCRIPTION
## Summary
- Configure Vite `base` path for `/pomoflex/` subdirectory
- Add GitHub Actions workflow that builds and deploys to GitHub Pages on push to main

## Setup Required
After merging, enable GitHub Pages in the repository settings:
1. Go to Settings → Pages
2. Under "Build and deployment", select "GitHub Actions" as the source

Closes #9

## Test plan
- [ ] Merge PR and verify workflow runs successfully
- [ ] Confirm app is accessible at https://mlw214.github.io/pomoflex

🤖 Generated with [Claude Code](https://claude.com/claude-code)