### PR TITLE
feat: add partial break selection UI

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -48,7 +48,7 @@
       {/if}
       <button class="secondary" on:click={timer.stop}>Stop</button>
     {:else if $timerState === "rollover"}
-      <div class="break-selector">
+      <div class="rollover-controls">
         <span class="break-label">Take a break:</span>
         <div class="break-options">
           {#each availablePresets as preset (preset.seconds)}
@@ -65,8 +65,10 @@
             </button>
           {/if}
         </div>
+        <button class="secondary skip-btn" on:click={timer.skipBreak}
+          >Skip</button
+        >
       </div>
-      <button class="secondary" on:click={timer.skipBreak}>Skip</button>
     {:else if $timerState === "break"}
       <button class="secondary" on:click={timer.stop}>End Break</button>
     {/if}
@@ -146,11 +148,11 @@
     letter-spacing: 0.1em;
   }
 
-  .break-selector {
+  .rollover-controls {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--spacing-md);
   }
 
   .break-label {
@@ -170,9 +172,14 @@
     font-size: var(--font-size-sm);
     background-color: var(--color-break);
     color: var(--color-bg);
+    min-width: 70px;
   }
 
   .break-option:hover {
     filter: brightness(0.9);
+  }
+
+  .skip-btn {
+    min-width: 70px;
   }
 </style>


### PR DESCRIPTION
## Summary
- Add preset break duration buttons (5/10/15 min) during rollover state
- Only show presets that fit within the current deficit
- Add "All" button when deficit exceeds highest preset, showing full amount
- Deficit correctly decreases by selected break duration

Closes #17

## Test plan
- [ ] Start work session and let it complete to enter rollover
- [ ] Verify preset buttons appear based on available deficit
- [ ] Verify "All" button shows when deficit > 15 min
- [ ] Click a partial break option and verify:
  - Break timer starts with selected duration
  - Deficit decreases by that amount
- [ ] Verify Skip button still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)