### PR TITLE
fix: simplify break selector for mobile

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -26,9 +26,6 @@
 
   // Filter presets to only show those <= current deficit
   $: availablePresets = BREAK_PRESETS.filter((p) => p.seconds <= $breakDeficit);
-  $: showAllButton =
-    $breakDeficit > 0 &&
-    !availablePresets.some((p) => p.seconds === $breakDeficit);
 </script>
 
 <main>
@@ -59,11 +56,6 @@
               {preset.label}
             </button>
           {/each}
-          {#if showAllButton}
-            <button class="break-option" on:click={() => timer.takeBreak()}>
-              All ({formatDuration($breakDeficit)})
-            </button>
-          {/if}
         </div>
         <button class="secondary skip-btn" on:click={timer.skipBreak}
           >Skip</button
@@ -163,7 +155,6 @@
   .break-options {
     display: flex;
     gap: var(--spacing-sm);
-    flex-wrap: wrap;
     justify-content: center;
   }
 
@@ -172,7 +163,6 @@
     font-size: var(--font-size-sm);
     background-color: var(--color-break);
     color: var(--color-bg);
-    min-width: 70px;
   }
 
   .break-option:hover {


### PR DESCRIPTION
## Summary
- Remove "All" button - only show 5/10/15 min presets
- Simplify CSS - no flex wrapping needed
- Consistent button sizing across all states

## Test plan
- [ ] Verify break options show correctly with varying banked amounts
- [ ] Check mobile layout looks good
- [ ] Check desktop layout looks good

🤖 Generated with [Claude Code](https://claude.ai/claude-code)