### PR TITLE
fix: center break options by using consistent button widths

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -163,13 +163,10 @@
     font-size: var(--font-size-sm);
     background-color: var(--color-break);
     color: var(--color-bg);
+    min-width: 5rem;
   }
 
   .break-option:hover {
     filter: brightness(0.9);
-  }
-
-  .skip-btn {
-    min-width: 70px;
   }
 </style>


### PR DESCRIPTION
## Summary
- Fixed the Skip button appearing off-center in rollover state
- The issue was caused by break duration buttons (5/10/15 min) having different widths based on text content
- Added `min-width: 5rem` to `.break-option` to ensure all buttons are equal width

Closes #42

## Test plan
- [ ] Complete a work session to enter rollover state
- [ ] Verify the Skip button is centered below the break duration options
- [ ] Test with 1, 2, and 3 visible break options

🤖 Generated with [Claude Code](https://claude.com/claude-code)